### PR TITLE
Introduce central bus and interrupt handling

### DIFF
--- a/src/bus.ts
+++ b/src/bus.ts
@@ -1,0 +1,11 @@
+import { CPU } from './cpu';
+import { GPU } from './gpu';
+import { MMU } from './mmu';
+import { InterruptController } from './interrupt';
+
+export class GameBoyBus {
+    cpu!: CPU;
+    gpu!: GPU;
+    mmu!: MMU;
+    interrupts: InterruptController = new InterruptController();
+}

--- a/src/cpu.ts
+++ b/src/cpu.ts
@@ -1,4 +1,5 @@
 import { Registers } from "./registers"
+import { GameBoyBus } from "./bus"
 
 
 
@@ -16,6 +17,7 @@ export class CPU {
     state = State.running;
 
     registers: Registers;
+    bus: GameBoyBus;
 
     reset_carry_flag() {
         this.registers.f &= ~(1 << 4)
@@ -49,9 +51,9 @@ export class CPU {
         this.registers.f |= 1 << 7
     }
 
-    constructor(registers: Registers) {
-
-        this.registers = registers;
+    constructor(bus: GameBoyBus) {
+        this.bus = bus;
+        this.registers = new Registers();
     }
 
     // reset CPU

--- a/src/gameboy.ts
+++ b/src/gameboy.ts
@@ -117,7 +117,6 @@ export class Gameboy {
                         handler = 0x0060; // Hi-Lo of P10-P13
                 }
 
-
                 if (handler != 0) {
 
                         // set IME to 0
@@ -164,11 +163,13 @@ export class Gameboy {
                 }
 
                 let clock_count = 0;
-
                 // one frame timing
                 while (clock_count < clock_count_MAX) {
 
-                        if(log_buffer != undefined){ log_buffer = log_buffer + this.getLog() + '\n'}
+			if (log_buffer !== undefined) {
+			    log_buffer = (log_buffer + this.getLog() + '\n').trim().split('\n').slice(-50).join('\n') + '\n';
+			}
+
                         // check for interrupts
                         this.HandleInterrupts();
 
@@ -176,7 +177,7 @@ export class Gameboy {
 
                         if (old_pc == breakpoint && breakpoint != -1) {
                                 console.log(`Emulator halted on PC==${old_pc.toString(16)}`)
-                                return 0;
+                                return 0; 
                         }
 
                         let { arg, new_pc, inst } = this.FetchOpCode();
@@ -190,15 +191,16 @@ export class Gameboy {
 
                         clock_count += inst.cycles;
 
-                        
-                        this.gpu.RunClocks(clock_count);
+
+                        this.gpu.RunClocks(inst.cycles);
                 }
                 if(log_buffer != undefined){return log_buffer};
         }
         getLog(): string {
                 // FORMAT
                 // A:00 F:11 B:22 C:33 D:44 E:55 H:66 L:77 SP:8888 PC:9999 PCMEM:AA,BB,CC,DD
-                let log = `A:${this.cpu.registers.a.toString(16).padStart(2,'0')} F:${this.cpu.registers.f.toString(16).padStart(2,'0')} B:${this.cpu.registers.b.toString(16).padStart(2,'0')} C:${this.cpu.registers.c.toString(16).padStart(2,'0')} D:${this.cpu.registers.d.toString(16).padStart(2,'0')} E:${this.cpu.registers.e.toString(16).padStart(2,'0')} H:${this.cpu.registers.h.toString(16).padStart(2,'0')} L:${this.cpu.registers.l.toString(16).padStart(2,'0')} SP:${this.cpu.registers.sp.toString(16).padStart(4,'0')} PC:${this.cpu.registers.pc.toString(16).padStart(4,'0')} PCMEM:${this.mmu.getByte(this.cpu.registers.pc).toString(16).padStart(2,'0')},${this.mmu.getByte(this.cpu.registers.pc + 1).toString(16).padStart(2,'0')},${this.mmu.getByte(this.cpu.registers.pc + 2).toString(16).padStart(2,'0')},${this.mmu.getByte(this.cpu.registers.pc + 3).toString(16).padStart(2,'0')}`;
+                let log = `LY:${this.mmu.getByte(0xFF44)} A:${this.cpu.registers.a.toString(16).padStart(2,'0')} F:${this.cpu.registers.f.toString(16).padStart(2,'0')} B:${this.cpu.registers.b.toString(16).padStart(2,'0')} C:${this.cpu.registers.c.toString(16).padStart(2,'0')} D:${this.cpu.registers.d.toString(16).padStart(2,'0')} E:${this.cpu.registers.e.toString(16).padStart(2,'0')} H:${this.cpu.registers.h.toString(16).padStart(2,'0')} L:${this.cpu.registers.l.toString(16).padStart(2,'0')} SP:${this.cpu.registers.sp.toString(16).padStart(4,'0')} PC:${this.cpu.registers.pc.toString(16).padStart(4,'0')} PCMEM:${this.mmu.getByte(this.cpu.registers.pc).toString(16).padStart(2,'0')},${this.mmu.getByte(this.cpu.registers.pc + 1).toString(16).padStart(2,'0')},${this.mmu.getByte(this.cpu.registers.pc + 2).toString(16).padStart(2,'0')},${this.mmu.getByte(this.cpu.registers.pc + 3).toString(16).padStart(2,'0')}`;
+
                 return log.toUpperCase();
         }
 }

--- a/src/gpu.ts
+++ b/src/gpu.ts
@@ -1,4 +1,6 @@
 import { MMU } from "./mmu";
+import { GameBoyBus } from "./bus";
+import { Int } from "./interrupt";
 
 
 
@@ -17,11 +19,13 @@ function get_RGB(color: number): number[] {
 
 
 export class GPU {
+    bus: GameBoyBus;
 
 
 
 
-    constructor() {
+    constructor(bus: GameBoyBus) {
+        this.bus = bus;
         this.reset();
     }
 
@@ -116,6 +120,7 @@ export class GPU {
                     this.ly++;
 
                     if (this.ly == 143) {
+                        this.bus.interrupts.request(Int.VBlank);
                         // Enter vblank
                         this.mode = 1;
                         // this.canvas.putImageData(this.screen, 0, 0);

--- a/src/gpu.ts
+++ b/src/gpu.ts
@@ -121,6 +121,8 @@ export class GPU {
 
                     if (this.ly == 143) {
                         this.bus.interrupts.request(Int.VBlank);
+			console.log("Requesting VBLANK from gpu....");
+			console.log(this.bus.interrupts);
                         // Enter vblank
                         this.mode = 1;
                         // this.canvas.putImageData(this.screen, 0, 0);

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -2874,7 +2874,7 @@ export class InstructionGetter {
                 return {
                     op: function(args: op_args) {
                         // interrupt master enable
-                        args.mmu.ime = 0x0;
+                        args.mmu.bus.interrupts.IME = 0x0;
                     },
                     cycles: 4,
                     arg_number: 0,
@@ -2884,7 +2884,7 @@ export class InstructionGetter {
             case 0xFB: {
                 return {
                     op: function(args: op_args) {
-                        args.mmu.ime = 0x1;
+                        args.mmu.bus.interrupts.IME = 0x1;
                     },
                     cycles: 4,
                     arg_number: 0,

--- a/src/interrupt.ts
+++ b/src/interrupt.ts
@@ -1,0 +1,17 @@
+export enum Int {
+    VBlank = 0,
+    LCDStat = 1,
+    Timer = 2,
+    Serial = 3,
+    Joypad = 4
+}
+
+export class InterruptController {
+    IE: number = 0;
+    IF: number = 0;
+    IME: number = 1;
+
+    request(i: Int) {
+        this.IF |= 1 << i;
+    }
+}

--- a/src/mmu.ts
+++ b/src/mmu.ts
@@ -133,8 +133,8 @@ export class MMU {
                 if (address == 0xFF42) { return this.gpu.scy; }
                 if (address == 0xFF43) { return this.gpu.scx; }
                 // HARDCODE THIS TO USE GB DEBUGGER
-                // if (address == 0xFF44) { return this.gpu.ly; }
-                if (address == 0xFF44) { return 0x90; }
+                // if (address == 0xFF44) { return 0x90; }
+                if (address == 0xFF44) { return this.gpu.ly; }
                 if (address == 0xFF45) { return this.gpu.lyc; }
                 if (address == 0xFF46) { return this.gpu.dma; }
                 if (address == 0xFF47) { return this.gpu.bgp; }

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -1,6 +1,7 @@
 
 import { CPU } from "./cpu"
 import { GPU } from "./gpu"
+import { GameBoyBus } from "./bus"
 import { Registers } from "./registers"
 import { MMU } from "./mmu"
 import { InstructionConfig, InstructionGetter } from "./instructions"
@@ -16,13 +17,17 @@ describe('BOOTROM', function() {
     let cpu: CPU;
     let mmu: MMU;
     let gpu: GPU;
+    let bus: GameBoyBus;
 
     beforeEach("init", function() {
 
-        gpu = new GPU();
-        cpu = new CPU(new Registers());
+        bus = new GameBoyBus();
+        gpu = new GPU(bus);
+        bus.gpu = gpu;
+        cpu = new CPU(bus);
         // load bootrom on MMU
-        mmu = new MMU(gpu  );
+        mmu = new MMU(bus);
+        bus.mmu = mmu;
 
     });
 
@@ -69,13 +74,17 @@ describe('logic instructions', function() {
     let cpu: CPU;
     let mmu: MMU;
     let gpu: GPU;
+    let bus: GameBoyBus;
 
     beforeEach("init", function() {
 
-        gpu = new GPU();
-        cpu = new CPU(new Registers());
+        bus = new GameBoyBus();
+        gpu = new GPU(bus);
+        bus.gpu = gpu;
+        cpu = new CPU(bus);
         // load bootrom on MMU
-        mmu = new MMU(gpu);
+        mmu = new MMU(bus);
+        bus.mmu = mmu;
 
     });
 
@@ -153,13 +162,17 @@ describe('other instructions', function() {
     let cpu: CPU;
     let mmu: MMU;
     let gpu: GPU;
+    let bus: GameBoyBus;
 
     beforeEach("init", function() {
 
-        cpu = new CPU(new Registers());
-        gpu = new GPU();
+        bus = new GameBoyBus();
+        cpu = new CPU(bus);
+        gpu = new GPU(bus);
+        bus.gpu = gpu;
         // load bootrom on MMU
-        mmu = new MMU( gpu);
+        mmu = new MMU(bus);
+        bus.mmu = mmu;
 
     });
 


### PR DESCRIPTION
## Summary
- implement `InterruptController` and enumerated types
- add `GameBoyBus` to hold components and interrupts
- refactor CPU, GPU, MMU to accept a bus
- update `Gameboy` to wire components using the bus
- raise VBlank interrupt from GPU
- adapt tests to new constructors

## Testing
- `npm run build`
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861b29d3aa8832c94e0de3d5cb45254